### PR TITLE
商品削除機能#9

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,10 +38,10 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    if current_user.id == item.user_id 
-      item.destroy
-      redirect_to root_path
-    end
+    return unless current_user.id == item.user_id
+
+    item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,12 +38,12 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-      if current_user.id == item.user_id
-        item.destroy
-        redirect_to root_path
-      else
-        redirect_to root_path
-      end
+    if current_user.id == item.user_id
+      item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,10 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
+    if current_user.id == item.user_id 
+      item.destroy
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,10 +38,12 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    return unless current_user.id == item.user_id
-
-    item.destroy
-    redirect_to root_path
+      if current_user.id == item.user_id
+        item.destroy
+        redirect_to root_path
+      else
+        redirect_to root_path
+      end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update]
+
   def index
     @items = Item.all.order('created_at DESC')
   end
@@ -33,6 +34,12 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
         <% if current_user.id == @item.user_id %>
           <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-          <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+          <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
         <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
商品詳細ページにて、自分が出品した商品ならば削除ができる機能の実装

# Why
販売者が出品後に商品の登録時から変更があった場合や、登録内容の間違いがあった際に登録を削除するため。

# 補足資料
**資料1**
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
URL:https://i.gyazo.com/07850602ae0e2a7ddbfeb31083d6d966.mp4